### PR TITLE
Rights metadata bugfix

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -139,7 +139,7 @@ migration_nodes:
     method: Mapping::Rights.unprocessed
     qualifiers:
       default:
-        form_field_name: additional_information
+        form_field_name: rights
         method: Mapping::Rights.ignored
       uri:
         form_field_name: rights

--- a/config/default.yml
+++ b/config/default.yml
@@ -139,7 +139,8 @@ migration_nodes:
     method: Mapping::Rights.unprocessed
     qualifiers:
       default:
-        form_field_name: rights
+        form_field_name: additional_information
+        method: Mapping::Rights.ignored
       uri:
         form_field_name: rights
   subject:

--- a/config/etd.yml
+++ b/config/etd.yml
@@ -101,6 +101,7 @@ migration_nodes:
     qualifiers:
       default:
         form_field_name: rights
+        method: Mapping::Rights.ignored
       uri:
         form_field_name: rights
   subject:

--- a/config/example.yml
+++ b/config/example.yml
@@ -101,6 +101,7 @@ migration_nodes:
     qualifiers:
       default:
         form_field_name: rights
+        method: Mapping::Rights.ignored
       uri:
         form_field_name: rights
   subject:

--- a/lib/mapping/extensions/basic_value_handler.rb
+++ b/lib/mapping/extensions/basic_value_handler.rb
@@ -1,14 +1,30 @@
 module Mapping
   module Extensions
     module BasicValueHandler
-      def unprocessed(value)
-        value
+      ##
+      # This mapped value is to be ignored and not included in the migration
+      # @parameter [String] value - the value
+      # @returns [Nil] - a nil
+      def ignored(_value)
+        nil
       end
 
+      ##
+      # The mapped value is passed through with no modification or mapping
+      # @parameter [String] value - the value
+      # @returns [String] - the value with leading and trailing whitespace stripped
+      def unprocessed(value)
+        value.strip
+      end
+
+      ##
+      # This mapped value is returned with some text prepended to it
+      # @parameter [String] value - the value
+      # @parameter [*String] args - a variable number of string arguments
+      # @returns [String] - the value with text from the args prepended to it
       def prepend(value, *args)
-        "#{args.join(',')} #{value}"
+        "#{args.join(',')} #{unprocessed(value)}"
       end
     end
   end
 end
-

--- a/lib/metadata/class_method_runner.rb
+++ b/lib/metadata/class_method_runner.rb
@@ -1,6 +1,77 @@
 module Metadata
   module ClassMethodRunner
     ##
+    # From an API perspective, this is the only public method intended to be called.
+    # Process 'run_method' and add value(s) to data hash
+    # @param [Hash] data - the data hash to add processed values to
+    # @return [Hash] - the data hash with the new node/values injected
+    def process_node(data = {})
+      # run_method may return a String, Array<String>, or an Array<Hash>
+      result = run_method
+
+      # a nil result from a method indicates that the value should not be mapped/migrated
+      return data if result.nil?
+      update_data(result, data)
+    end
+
+    private
+
+    def method
+      @config['method']
+    end
+
+    def has_method?
+      !method.nil?
+    end
+
+    def content
+      @config['value']
+    end
+
+    def field_name
+      form_field(@config['form_field_name'])
+    end
+
+    ##
+    # Given the value from this, run the method configured for the qualifier if it exists otherwise the default
+    # @return [String] - the result of the configured method should be a string to store in hydra
+    def run_method
+      raise StandardError.new("#{field} run_method is missing method configuration") unless has_method?
+      send(method, content)
+    end
+
+    ##
+    # Methods can return String, Array<String>, or Hash<:field_name,:value>.
+    #
+    # Add the result from the configured method to the data hash of arrays
+    # given the field name configured or field_name provided by the result of the
+    # configured method.
+    # @param [String, Array<String>, Hash<:field_name,:value>] result - the result of the configured method
+    # @param [Hash] data - the data hash of the processed Metadata
+    # @return [Hash] - the updated data hash
+    def update_data(result, data)
+      if result.is_a?(String)
+        # ensure the form_field is set in the hash and add the processed value to it
+        data[field_name] ||= []
+        data[field_name] << result
+      else
+        # run_method returns an array of hashes or strings
+        # when the array returns hashes, it expects the shape to be { field_name: '', value: ''}
+        # when the array returns strings, add each to the array of the field_name configured for the node
+        result.each do |r|
+          if r.is_a?(Hash)
+            data[form_field(r[:field_name])] ||= []
+            data[form_field(r[:field_name])] << r[:value].to_s
+          else
+            data[field_name] ||= []
+            data[field_name] << r.to_s
+          end
+        end
+      end
+      data
+    end
+
+    ##
     # Call a class method passing in an array of values, with the method expecting the first argument to be the value passed
     # into this 'send' method followed by a variable number of additional arguments. The idea here is that the configuration
     # could include some specific values to provide to the target method to aid in processing.
@@ -14,10 +85,23 @@ module Metadata
       class_method = method.first.split('.') if method.is_a?(Array)
       class_method = method.split('.') if method.is_a?(String)
       klass = Object.const_get(class_method.first)
-      if method.is_a? Array
-        values << method.drop(1).map { |x| x }
-      end
+      values << method.drop(1).map { |x| x } if method.is_a? Array
       klass.send(class_method.last, *values)
+    end
+
+    ##
+    # Return the formatted form_field using the provided form_field_name or this nodes qualifiers configured form_field_name
+    # Pertinent portion of example configuration:
+    # description:
+    #   form_field: "generic_work['%{form_field_name}'][]"
+    #   qualifiers:
+    #     default:
+    #       form_field_name: some_field_name
+    # @param String form_field_name - a provided string name for the form_field_name
+    # @return String - the properly formatted form field name by this nodes configured "form_field" and
+    #                   the provided form_field_name or the qualifiers configured "form_field_name"
+    def form_field(form_field_name = nil)
+      sprintf(@config['form_field'], work_type: @work_type, form_field_name: form_field_name)
     end
   end
 end

--- a/lib/metadata/custom_node.rb
+++ b/lib/metadata/custom_node.rb
@@ -1,74 +1,11 @@
 module Metadata
   class CustomNode
     include ClassMethodRunner
-    attr_reader :config, :field
+    attr_reader :config
 
     def initialize(work_type, config = {})
       @config = config
       @work_type = work_type
-    end
-
-    ##
-    # Process 'run_method' and add value(s) to data hash
-    # @param [Hash] data - the data hash to add processed values to
-    # @return [Hash] - the data hash with the new node/values injected
-    def process_node(data = {})
-      # run_method may return a String, Array<String>, or an Array<Hash>
-      result = run_method
-      if result.is_a?(String)
-        # ensure the form_field is set in the hash and add the processed value to it
-        data[field_name] ||= []
-        data[field_name] << result
-      else
-        # run_method returns an array of hashes or strings
-        # when the array returns hashes, it expects the shape to be { field_name: '', value: ''}
-        # when the array returns strings, add each to the array of the field_name configured for the node
-        result.each do |r|
-          if r.is_a?(Hash)
-            data[form_field(r[:field_name])] ||= []
-            data[form_field(r[:field_name])] << r[:value].to_s
-          else
-            data[field_name] ||= []
-            data[field_name] << r.to_s
-          end
-        end
-      end
-      data
-    end
-
-    ##
-    # Given the value from this, run the method configured for the qualifier if it exists otherwise the default
-    # @return [String] the result of the configured method should be a string to store in hydra
-    def run_method
-        raise StandardError.new("#{field} run_method is missing method configuration") unless has_method?
-        send(method, @config['value'])
-    end
-
-    def method
-      @config['method']
-    end
-
-    def has_method?
-      !method.nil?
-    end
-
-    def field_name
-      form_field(@config['form_field_name'])
-    end
-
-    ##
-    # Return the formatted form_field using the provided form_field_name or this nodes qualifiers configured form_field_name
-    # Pertinent portion of example configuration:
-    # description:
-    #   form_field: "generic_work['%{form_field_name}'][]"
-    #   qualifiers:
-    #     default:
-    #       form_field_name: some_field_name
-    # @param String form_field_name - a provided string name for the form_field_name
-    # @return String - the properly formatted form field name by this nodes configured "form_field" and
-    #                   the provided form_field_name or the qualifiers configured "form_field_name"
-    def form_field(form_field_name = nil)
-      sprintf(@config['form_field'], { work_type: @work_type, form_field_name: form_field_name })
     end
   end
 end

--- a/spec/lib/mapping/extensions/basic_value_handler_spec.rb
+++ b/spec/lib/mapping/extensions/basic_value_handler_spec.rb
@@ -1,9 +1,12 @@
 RSpec.describe Mapping::Extensions::BasicValueHandler do
-  let(:klass) { Class.new { extend Mapping::Extensions::BasicValueHandler }}
+  let(:klass) { Class.new { extend Mapping::Extensions::BasicValueHandler } }
+  it 'returns a nil' do
+    expect(klass.ignored('blah')).to be_nil
+  end
   it 'returns an unprocessed value' do
-    expect(klass.unprocessed('blah')).to eq "blah"
+    expect(klass.unprocessed('blah')).to eq 'blah'
   end
   it 'returns a value with text prepended' do
-    expect(klass.prepend('foo', ["oh noes!"])).to eq "oh noes! foo"
+    expect(klass.prepend('foo', ['oh noes!'])).to eq 'oh noes! foo'
   end
 end

--- a/spec/lib/metadata/custom_node_spec.rb
+++ b/spec/lib/metadata/custom_node_spec.rb
@@ -1,72 +1,63 @@
 class CustomNodeSomeClass
-  def self.test_method(value, *args)
+  def self.test_method(value, *_args)
     "executed test_method with value #{value}"
   end
 
-  def self.test_array_string_method(value, *args)
-    return ["one", "two"]
+  def self.test_array_string_method(_value, *_args)
+    %w(one two)
   end
 
-  def self.test_array_hash_method(value, *args)
-    return [{field_name: "field", value: "value1"},{field_name: "field2", value:"value2"}]
+  def self.test_array_hash_method(_value, *_args)
+    [{ field_name: 'field', value: 'value1' }, { field_name: 'field2', value: 'value2' }]
   end
 end
 
 RSpec.describe Metadata::CustomNode do
   subject { Metadata::CustomNode.new work_type, config }
 
-  let(:work_type) { "default_work" }
-  let(:config) {
+  let(:work_type) { 'default_work' }
+  let(:config) do
     {
-      "form_field" => "%{work_type}['%{form_field_name}'][]",
-      "method" => "CustomNodeSomeClass.test_method",
-      "form_field_name" => "field_name",
-      "value" => "testeroni"
+      'form_field' => "%{work_type}['%{form_field_name}'][]",
+      'method' => 'CustomNodeSomeClass.test_method',
+      'form_field_name' => 'field_name',
+      'value' => 'testeroni'
     }
-  }
-  let(:data){{}}
-
-  it "has a method" do
-    expect(subject.has_method?).to be_truthy
-    expect(subject.method).to eq config['method']
   end
+  let(:data) { {} }
 
-  it "has a form_field_name supplied to it" do
-    expect(subject.form_field('blahblah')).to eq "default_work['blahblah'][]"
-  end
-
-  it "can process_node" do
+  it 'can process_node' do
     result = subject.process_node(data)
-    expect(result.has_key?("default_work['field_name'][]")).to be_truthy
+    expect(result.key?("default_work['field_name'][]")).to be_truthy
   end
 
-  context "with a string array method configured" do
-    let(:config) {
+  context 'with a string array method configured' do
+    let(:config) do
       {
-        "method" => "CustomNodeSomeClass.test_array_string_method",
-        "form_field" => "%{work_type}['%{form_field_name}'][]",
-        "form_field_name" => "field_name",
-        "value" => "blah"
+        'method' => 'CustomNodeSomeClass.test_array_string_method',
+        'form_field' => "%{work_type}['%{form_field_name}'][]",
+        'form_field_name' => 'field_name',
+        'value' => 'blah'
       }
-    }
+    end
 
-    it "can run_method" do
-      expect(subject.has_method?).to be_truthy
-      expect(subject.run_method).to eq ["one", "two"]
+    it 'can process_node' do
+      result = subject.process_node(data)
+      expect(result.values.length).to eq 1
+      expect(result.values.first).to eq %w(one two)
     end
   end
-  context "with a hash array method configured" do
-    let(:config) {
+  context 'with a hash array method configured' do
+    let(:config) do
       {
-        "method" => "CustomNodeSomeClass.test_array_hash_method",
-        "form_field" => "%{work_type}['%{form_field_name}'][]",
-        "form_field_name" => "field_name",
-        "value" => "blah"
+        'method' => 'CustomNodeSomeClass.test_array_hash_method',
+        'form_field' => "%{work_type}['%{form_field_name}'][]",
+        'form_field_name' => 'field_name',
+        'value' => 'blah'
       }
-    }
+    end
 
-    it "can run_method" do
-      expect(subject.has_method?).to be_truthy
+    it 'can run_method' do
       expect(subject.process_node(data).values.length).to eq 2
       expect(subject.process_node(data).keys.length).to eq 2
     end

--- a/spec/lib/metadata/node_spec.rb
+++ b/spec/lib/metadata/node_spec.rb
@@ -1,14 +1,14 @@
 class NodeSomeClass
-  def self.test_method(value, *args)
+  def self.test_method(value, *_args)
     "executed test_method with value #{value}"
   end
 
-  def self.test_array_string_method(value, *args)
-    return ["one", "two"]
+  def self.test_array_string_method(_value, *_args)
+    %w(one two)
   end
 
-  def self.test_array_hash_method(value, *args)
-    return [{field_name: "field", value: "value1"},{field_name: "field2", value:"value2"}]
+  def self.test_array_hash_method(_value, *_args)
+    [{ field_name: 'field', value: 'value1' }, { field_name: 'field2', value: 'value2' }]
   end
 end
 
@@ -17,112 +17,64 @@ RSpec.describe Metadata::Node do
 
   let(:xml_doc) { Nokogiri::XML('<metadata><value schema="dc" element="some_element">A value</value></metadata>') }
   let(:xml_node) { xml_doc.at_xpath(config['xpath']) }
-  let(:field) { "some_element" }
-  let(:work_type) { "default_work" }
-  let(:config) {
+  let(:field) { 'some_element' }
+  let(:work_type) { 'default_work' }
+  let(:config) do
     {
-      "xpath" => "//metadata/value[@element='some_element']",
-      "form_field" => "generic_work['%{form_field_name}'][]",
-      "method" => "NodeSomeClass.test_method",
-      "qualifiers" =>  {
-        "default" => {
-          "form_field_name" => "field_name"
+      'xpath' => "//metadata/value[@element='some_element']",
+      'form_field' => "generic_work['%{form_field_name}'][]",
+      'method' => 'NodeSomeClass.test_method',
+      'qualifiers' => {
+        'default' => {
+          'form_field_name' => 'field_name'
         },
-        "test_qualifier" => {
-          "form_field_name" => "test_field_name",
+        'test_qualifier' => {
+          'form_field_name' => 'test_field_name'
         }
       }
     }
-  }
-  let(:data){{}}
-
-  it "has a qualifier" do
-    expect(subject.qualifier).to be_a_kind_of Metadata::Qualifier
   end
+  let(:data) { {} }
 
-  it "has an xpath" do
-    expect(subject.xpath).to eq config['xpath']
-  end
-
-  it "has a method" do
-    expect(subject.has_method?).to be_truthy
-    expect(subject.method).to eq config['method']
-  end
-
-  it "has a qualifier with a form_field" do
-    expect(subject.form_field).to eq "generic_work['field_name'][]"
-  end
-
-  it "has a form_field_name supplied to it" do
-    expect(subject.form_field('blahblah')).to eq "generic_work['blahblah'][]"
-  end
-
-  it "can process_node" do
+  it 'can process_node' do
     result = subject.process_node(data)
-    expect(result.has_key?("generic_work['field_name'][]")).to be_truthy
+    expect(result.key?("generic_work['field_name'][]")).to be_truthy
   end
 
-  context "with qualifier in the node" do
+  context 'with qualifier in the node' do
     let(:xml_doc) { Nokogiri::XML('<metadata><value schema="dc" element="some_element" qualifier="test_qualifier">Graduation: 2245</value></metadata>') }
-    it "has a qualifier" do
-      expect(subject.qualifier).to be_a_kind_of Metadata::Qualifier
-      expect(subject.content).to eq "Graduation: 2245"
-    end
 
-    it "can run_method" do
-      expect(subject.run_method).to eq "executed test_method with value Graduation: 2245"
+    it 'can process_node' do
+      result = subject.process_node(data)
+      expect(result.values[0]).to eq ['executed test_method with value Graduation: 2245']
     end
   end
 
-  context "with a default method configured" do
-    let(:config) {
-      {
-        "xpath" => "//metadata/value[@element='some_element']",
-        "method" => "NodeSomeClass.test_method",
-        "form_field" => "generic_work['%{form_field_name}'][]",
-        "qualifiers" =>  {
-          "default" => {
-            "form_field_name" => "field_name"
-          },
-          "test_qualifier" => {
-            "form_field_name" => "test_field_name",
-            "method" => "NodeSomeClass.test_method"
-          }
-        }
-      }
-    }
-
-    it "can run_method" do
-      expect(subject.has_method?).to be_truthy
-      expect(subject.run_method).to eq "executed test_method with value A value"
-    end
-
-    context "with args on the method" do
-      let(:config) {
+  context 'with a default method configured' do
+    context 'with args on the method' do
+      let(:config) do
         {
-          "xpath" => "//metadata/value[@element='some_element']",
-          "method" => ["NodeSomeClass.test_array_string_method", "arg1", "arg2"],
-          "form_field" => "generic_work['%{form_field_name}'][]",
-          "qualifiers" =>  {
-            "default" => {
-              "form_field_name" => "field_name"
+          'xpath' => "//metadata/value[@element='some_element']",
+          'method' => ['NodeSomeClass.test_array_string_method', 'arg1', 'arg2'],
+          'form_field' => "generic_work['%{form_field_name}'][]",
+          'qualifiers' => {
+            'default' => {
+              'form_field_name' => 'field_name'
             },
-            "test_qualifier" => {
-              "form_field_name" => "test_field_name",
-              "method" => ["NodeSomeClass.test_array_hash_method", "arg1", "arg2"]
+            'test_qualifier' => {
+              'form_field_name' => 'test_field_name',
+              'method' => ['NodeSomeClass.test_array_hash_method', 'arg1', 'arg2']
             }
           }
         }
-      }
-      it "can run_method" do
-        expect(subject.has_method?).to be_truthy
-        expect(subject.process_node(data).values[0]).to eq ["one","two"]
+      end
+      it 'can run_method' do
+        expect(subject.process_node(data).values[0]).to eq %w(one two)
       end
 
-      context "and a specific qualifier" do
+      context 'and a specific qualifier' do
         let(:xml_doc) { Nokogiri::XML('<metadata><value schema="dc" element="some_element" qualifier="test_qualifier">Graduation: 2245</value></metadata>') }
-        it "can run_method" do
-          expect(subject.has_method?).to be_truthy
+        it 'can run_method' do
           expect(subject.process_node(data).values.length).to eq 2
           expect(subject.process_node(data).keys.length).to eq 2
         end


### PR DESCRIPTION
Fixes #14 

Adds ability to explicitly ignore metadata (rights label)

The relevant code for this PR is the `default.yml`.. the `basic_value_handler.rb` addresses a bug related to the rights.uri having newline characters in it.