### PR TITLE
more agreement field to custom_nodes, ensure test allows for FixNum

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -4,6 +4,11 @@ upload_data:
   - directory: ORIGINAL
     ignore_files:
 custom_nodes:
+  agreement:
+    form_field: "%{form_field_name}"
+    form_field_name: agreement
+    method: Mapping::Agreement.unprocessed
+    value: 1
   visibility:
     form_field: "%{work_type}[%{form_field_name}]"
     form_field_name: visibility

--- a/config/etd.yml
+++ b/config/etd.yml
@@ -4,6 +4,11 @@ upload_data:
   - directory: ORIGINAL
     ignore_files:
 custom_nodes:
+  agreement:
+    form_field: "%{form_field_name}"
+    form_field_name: agreement
+    method: Mapping::Agreement.unprocessed
+    value: 1
   visibility:
     form_field: "%{work_type}[%{form_field_name}]"
     form_field_name: visibility

--- a/config/example.yml
+++ b/config/example.yml
@@ -4,6 +4,11 @@ upload_data:
   - directory: ORIGINAL
     ignore_files:
 custom_nodes:
+  agreement:
+    form_field: "%{form_field_name}"
+    form_field_name: agreement
+    method: Mapping::Agreement.unprocessed
+    value: 1
   visibility:
     form_field: "%{work_type}[%{form_field_name}]"
     form_field_name: visibility

--- a/dspace2hydra.rb
+++ b/dspace2hydra.rb
@@ -68,5 +68,7 @@ bag.files_for_upload.each do |item_file|
 end
 file_ids.flatten!.uniq!
 
-submitted_page = he.submit_new_work data, file_ids
+data.merge!({ "uploaded_files[]": file_ids })
+
+submitted_page = he.submit_new_work data
 pp submitted_page

--- a/lib/hydra_endpoint.rb
+++ b/lib/hydra_endpoint.rb
@@ -17,14 +17,9 @@ class HydraEndpoint
   end
 
   ##
-  def submit_new_work(data, file_ids=[])
+  def submit_new_work(data)
     csrf_token = @csrf_token || get_csrf_token
-    #TODO: dynamically generate the field for keyword and determine visibility
-    data.merge!({
-                  "#{@config['new_work']['csrf_form_field']}": csrf_token,
-                  "agreement": 1,
-                  "uploaded_files[]": file_ids
-                })
+    data.merge!({ "#{@config['new_work']['csrf_form_field']}": csrf_token })
     post_data @config['new_work']['form_action'], data
   end
 

--- a/lib/mapping/extensions/basic_value_handler.rb
+++ b/lib/mapping/extensions/basic_value_handler.rb
@@ -14,7 +14,8 @@ module Mapping
       # @parameter [String] value - the value
       # @returns [String] - the value with leading and trailing whitespace stripped
       def unprocessed(value)
-        value.strip
+        value.strip! if value.is_a? String
+        value
       end
 
       ##

--- a/lib/metadata/class_method_runner.rb
+++ b/lib/metadata/class_method_runner.rb
@@ -50,7 +50,7 @@ module Metadata
     # @param [Hash] data - the data hash of the processed Metadata
     # @return [Hash] - the updated data hash
     def update_data(result, data)
-      if result.is_a?(String)
+      if result.is_a?(String) || result.is_a?(Fixnum)
         # ensure the form_field is set in the hash and add the processed value to it
         data[field_name] ||= []
         data[field_name] << result

--- a/mapping/agreement.rb
+++ b/mapping/agreement.rb
@@ -1,0 +1,5 @@
+module Mapping
+  class Agreement
+    extend Extensions::BasicValueHandler
+  end
+end

--- a/spec/lib/metadata/node_spec.rb
+++ b/spec/lib/metadata/node_spec.rb
@@ -13,7 +13,7 @@ class NodeSomeClass
 end
 
 RSpec.describe Metadata::Node do
-  subject { Metadata::Node.new xml_node, field, work_type, config }
+  subject { Metadata::Node.new(xml_node, field, work_type, config).process_node(data) }
 
   let(:xml_doc) { Nokogiri::XML('<metadata><value schema="dc" element="some_element">A value</value></metadata>') }
   let(:xml_node) { xml_doc.at_xpath(config['xpath']) }
@@ -37,16 +37,14 @@ RSpec.describe Metadata::Node do
   let(:data) { {} }
 
   it 'can process_node' do
-    result = subject.process_node(data)
-    expect(result.key?("generic_work['field_name'][]")).to be_truthy
+    expect(subject.key?("generic_work['field_name'][]")).to be_truthy
   end
 
   context 'with qualifier in the node' do
     let(:xml_doc) { Nokogiri::XML('<metadata><value schema="dc" element="some_element" qualifier="test_qualifier">Graduation: 2245</value></metadata>') }
 
     it 'can process_node' do
-      result = subject.process_node(data)
-      expect(result.values[0]).to eq ['executed test_method with value Graduation: 2245']
+      expect(subject.values[0]).to eq ['executed test_method with value Graduation: 2245']
     end
   end
 
@@ -68,15 +66,15 @@ RSpec.describe Metadata::Node do
           }
         }
       end
-      it 'can run_method' do
-        expect(subject.process_node(data).values[0]).to eq %w(one two)
+      it 'can process_node' do
+        expect(subject.values[0]).to eq %w(one two)
       end
 
       context 'and a specific qualifier' do
         let(:xml_doc) { Nokogiri::XML('<metadata><value schema="dc" element="some_element" qualifier="test_qualifier">Graduation: 2245</value></metadata>') }
-        it 'can run_method' do
-          expect(subject.process_node(data).values.length).to eq 2
-          expect(subject.process_node(data).keys.length).to eq 2
+        it 'can process_node' do
+          expect(subject.values.length).to eq 2
+          expect(subject.keys.length).to eq 2
         end
       end
     end


### PR DESCRIPTION
moves `agreement` field to configuration to avoid future form field name change requiring code updates. 